### PR TITLE
Bump version to 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/galets/gnome-keyboard-reset",
   "session-modes": [


### PR DESCRIPTION
It wasn't working on debian testing (gnome shell 49).

I bumped the version and it seems to work.